### PR TITLE
Switch to the 2.0.0-alpha.0 steamlocate release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1542,7 +1542,7 @@ dependencies = [
  "wasm-streams",
  "web-sys",
  "webpki-roots",
- "winreg 0.10.1",
+ "winreg",
 ]
 
 [[package]]
@@ -1833,14 +1833,15 @@ checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
 
 [[package]]
 name = "steamlocate"
-version = "1.0.1"
-source = "git+https://github.com/CosmicHorrorDev/steamlocate-rs.git?branch=fully-switch-from-steamy-vdf#2d4e12ad03695ccca57679db08e4320fdb20afd9"
+version = "2.0.0-alpha.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b1568c4a70a26c4373fe1131ffa4eff055459631b6e40c6bc118615f2d870c3"
 dependencies = [
  "dirs",
  "keyvalues-parser",
  "keyvalues-serde",
  "serde",
- "winreg 0.11.0",
+ "winreg",
 ]
 
 [[package]]
@@ -2533,16 +2534,6 @@ version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
 dependencies = [
- "winapi",
-]
-
-[[package]]
-name = "winreg"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76a1a57ff50e9b408431e8f97d5456f2807f8eb2a2cd79b06068fc87f8ecf189"
-dependencies = [
- "cfg-if",
  "winapi",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ reqwest-middleware = "0.2.0"
 serde = { version = "1.0.155", features = ["derive"] }
 serde_json = "1.0.94"
 sha2 = "0.10.6"
-steamlocate = { git = "https://github.com/CosmicHorrorDev/steamlocate-rs.git", branch = "fully-switch-from-steamy-vdf" }
+steamlocate = "2.0.0-alpha.0"
 task-local-extensions = "0.1.3"
 thiserror = "1.0.39"
 tokio = { version = "1.25.0", features = ["full"] }


### PR DESCRIPTION
The `fully-switch-from-steamy-vdf` branch got released under 2.0.0-alpha.0