### PR TITLE
Use `directories` to store config and cache in proper directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 /target
 /hook/target
-/data
-.env

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -582,6 +582,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6798148dccfbff0fae41c7574d2fa8f1ef3492fba0face179de5d8d447d67b05"
+dependencies = [
+ "memchr",
+ "regex-automata",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1073,6 +1084,7 @@ dependencies = [
  "inventory",
  "lazy_static",
  "modio",
+ "opener",
  "regex",
  "repak",
  "reqwest",
@@ -2374,6 +2386,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "normpath"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec60c60a693226186f5d6edf073232bfb6464ed97eb22cf3b01c1e8198fd97f5"
+dependencies = [
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2524,6 +2545,17 @@ name = "once_cell"
 version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+
+[[package]]
+name = "opener"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c62dcb6174f9cb326eac248f07e955d5d559c272730b6c03e396b443b562788"
+dependencies = [
+ "bstr",
+ "normpath",
+ "winapi",
+]
 
 [[package]]
 name = "openssl"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -992,12 +992,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "directories"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a49173b84e034382284f27f1af4dcbbd231ffa358c0fe316541a7337f376a35"
+dependencies = [
+ "dirs-sys 0.4.1",
+]
+
+[[package]]
 name = "dirs"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30baa043103c9d0c2a57cf537cc2f35623889dc0d405e6c3cccfadbc81c71309"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
 ]
 
 [[package]]
@@ -1009,6 +1018,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -1040,6 +1061,7 @@ dependencies = [
  "async-trait",
  "clap",
  "dialoguer",
+ "directories",
  "eframe",
  "egui-dropdown",
  "egui_dnd",
@@ -2546,6 +2568,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "orbclient"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ image = { version = "0.24.6", default-features = false, features = ["png"] }
 inventory = "0.3.6"
 lazy_static = "1.4.0"
 modio = { version = "0.7.1", features = ["rustls-tls"] }
+opener = "0.6.1"
 regex = "1.8.3"
 repak = { git = "https://github.com/trumank/repak.git", version = "0.1.3" }
 reqwest = { version = "0.11.18", features = ["blocking"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ anyhow = { version = "1.0.71", features = ["backtrace"] }
 async-trait = "0.1.68"
 clap = { version = "4.3.0", features = ["derive"] }
 dialoguer = "0.10.4"
+directories = "5.0.1"
 eframe = "0.22.0"
 egui-dropdown = { git = "https://github.com/ItsEthra/egui-dropdown" }
 egui_dnd = "0.4.0"

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -97,7 +97,16 @@ impl ProfileNamePopup {
 impl App {
     fn new(args: Option<Vec<String>>) -> Result<Self> {
         let (tx, rx) = mpsc::channel(10);
+        let mut log = Log::default();
         let state = State::new()?;
+        log.println(format!(
+            "config dir: {}",
+            state.project_dirs.config_dir().display()
+        ));
+        log.println(format!(
+            "cache dir: {}",
+            state.project_dirs.cache_dir().display()
+        ));
 
         Ok(Self {
             args,
@@ -105,7 +114,7 @@ impl App {
             rx,
             request_counter: Default::default(),
             state,
-            log: Default::default(),
+            log,
             resolve_mod: Default::default(),
             resolve_mod_rid: None,
             integrate_rid: None,

--- a/src/gui/mod.rs
+++ b/src/gui/mod.rs
@@ -639,6 +639,20 @@ impl App {
                             }
                         });
                         ui.end_row();
+
+                        let config_dir = self.state.project_dirs.config_dir();
+                        ui.label("Config directory:");
+                        if ui.link(config_dir.display().to_string()).clicked() {
+                            opener::open(config_dir).ok();
+                        }
+                        ui.end_row();
+
+                        let cache_dir = self.state.project_dirs.cache_dir();
+                        ui.label("Cache directory:");
+                        if ui.link(cache_dir.display().to_string()).clicked() {
+                            opener::open(cache_dir).ok();
+                        }
+                        ui.end_row();
                     });
 
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::TOP), |ui| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,8 @@ struct ActionIntegrate {
     #[arg(short, long)]
     fsd_pak: Option<PathBuf>,
 
-    /// Update mods. By default all mods and metadata are cached offline so this is necessary to check for updates.
+    /// Update mods. By default all mods and metadata are cached offline so this is necessary to
+    /// check for updates.
     #[arg(short, long)]
     update: bool,
 
@@ -44,7 +45,8 @@ struct ActionIntegrateProfile {
     #[arg(short, long)]
     fsd_pak: Option<PathBuf>,
 
-    /// Update mods. By default all mods and metadata are cached offline so this is necessary to check for updates.
+    /// Update mods. By default all mods and metadata are cached offline so this is necessary to
+    /// check for updates.
     #[arg(short, long)]
     update: bool,
 


### PR DESCRIPTION
This PR leverages [`directories`](https://github.com/dirs-dev/directories-rs) to make the tool store its data and cache in the proper directories.

| Directory      | Value on Linux                                                                     | Value on Windows                                    | Value on macOS                                       |
|--------------------|------------------------------------------------------------------------------------|-----------------------------------------------------| ---------------------------------------------------- |
| `cache_dir`        | `$XDG_CACHE_HOME`/`<project_path>`        or `$HOME`/.cache/`<project_path>`       | `{FOLDERID_LocalAppData}`/`<project_path>`/cache    | `$HOME`/Library/Caches/`<project_path>`              |
| `config_dir`       | `$XDG_CONFIG_HOME`/`<project_path>`       or `$HOME`/.config/`<project_path>`      | `{FOLDERID_RoamingAppData}`/`<project_path>`/config | `$HOME`/Library/Application Support/`<project_path>` |

Closes #17.