### PR TITLE
[DO NOT MERGE] Transition to mod profiles being composed of mod groups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "hex",
  "hook",
  "image",
+ "indexmap 2.0.0",
  "inventory",
  "lazy_static",
  "modio",
@@ -2019,6 +2020,7 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+ "serde",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1122,6 +1122,7 @@ dependencies = [
  "inventory",
  "lazy_static",
  "modio",
+ "obake",
  "opener",
  "regex",
  "repak",
@@ -2521,6 +2522,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.27",
+]
+
+[[package]]
+name = "obake"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c016d34f5be5713bfcaa23668b736865921606c2ddff17e158f0815e4cde091b"
+dependencies = [
+ "obake_macros",
+]
+
+[[package]]
+name = "obake_macros"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47056b8eb01b867a9fdc29f69c05799b9eafb50f73e440cafe624949e27cc7dc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ egui_extras = "0.22.0"
 futures = "0.3.28"
 hex = "0.4.3"
 image = { version = "0.24.6", default-features = false, features = ["png"] }
+indexmap = { version = "2.0.0", features = ["serde"] }
 inventory = "0.3.6"
 lazy_static = "1.4.0"
 modio = { version = "0.7.1", features = ["rustls-tls"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ indexmap = { version = "2.0.0", features = ["serde"] }
 inventory = "0.3.6"
 lazy_static = "1.4.0"
 modio = { version = "0.7.1", features = ["rustls-tls"] }
+obake = { version = "1.0.5", features = ["serde"] }
 opener = "0.6.1"
 regex = "1.8.3"
 repak = { git = "https://github.com/trumank/repak.git", version = "0.1.3" }

--- a/README.md
+++ b/README.md
@@ -99,10 +99,3 @@ closed.**
 
 If you want to go back to the integrated mod support again, you must uninstall the mods installed by
 the integration tool. Then, launch the game normally.
-
-## Sharing your mod profiles
-
-Currently, the tool doesn't implement mod profile sharing. However, you can
-send (parts or the entirety of) your `profiles.json` to other players. This
-file can be found by going to the settings menu and clicking on the config
-dir link.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 pub mod error;
 pub mod gui;
 pub mod integrate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn action_integrate(action: ActionIntegrate) -> Result<()> {
         })
         .context("Could not find DRG pak file, please specify manually with the --fsd_pak flag")?;
 
-    let mut state = State::new()?;
+    let mut state = State::init()?;
 
     let mod_specs = action
         .mods
@@ -166,7 +166,7 @@ async fn action_integrate_mod_group(action: ActionIntegrateModGroup) -> Result<(
         })
         .context("Could not find DRG pak file, please specify manually with the --fsd_pak flag")?;
 
-    let mut state = State::new()?;
+    let mut state = State::init()?;
     let mod_group = &state.mod_data.groups[&action.mod_group];
 
     let mod_specs = mod_group

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,9 @@ struct ActionIntegrate {
     mods: Vec<String>,
 }
 
-/// Integrate a profile
+/// Integrate a mod group
 #[derive(Parser, Debug)]
-struct ActionIntegrateProfile {
+struct ActionIntegrateModGroup {
     /// Path to FSD-WindowsNoEditor.pak (FSD-WinGDK.pak for Microsoft Store version) located
     /// inside the "Deep Rock Galactic" installation directory under FSD/Content/Paks. Only
     /// necessary if it cannot be found automatically.
@@ -51,7 +51,7 @@ struct ActionIntegrateProfile {
     update: bool,
 
     /// Paths of mods to integrate
-    profile: String,
+    mod_group: String,
 }
 
 /// Launch via steam
@@ -63,7 +63,7 @@ struct ActionLaunch {
 #[derive(Subcommand, Debug)]
 enum Action {
     Integrate(ActionIntegrate),
-    Profile(ActionIntegrateProfile),
+    ModGroup(ActionIntegrateModGroup),
     Launch(ActionLaunch),
 }
 
@@ -86,8 +86,8 @@ fn main() -> Result<()> {
             action_integrate(action).await?;
             Ok(())
         }),
-        Some(Action::Profile(action)) => rt.block_on(async {
-            action_integrate_profile(action).await?;
+        Some(Action::ModGroup(action)) => rt.block_on(async {
+            action_integrate_mod_group(action).await?;
             Ok(())
         }),
         Some(Action::Launch(action)) => {
@@ -156,7 +156,7 @@ async fn action_integrate(action: ActionIntegrate) -> Result<()> {
     .await
 }
 
-async fn action_integrate_profile(action: ActionIntegrateProfile) -> Result<()> {
+async fn action_integrate_mod_group(action: ActionIntegrateModGroup) -> Result<()> {
     let path_game_pak = action
         .fsd_pak
         .or_else(|| {
@@ -167,9 +167,9 @@ async fn action_integrate_profile(action: ActionIntegrateProfile) -> Result<()> 
         .context("Could not find DRG pak file, please specify manually with the --fsd_pak flag")?;
 
     let mut state = State::new()?;
-    let profile = &state.profiles.profiles[&action.profile];
+    let mod_group = &state.mod_data.groups[&action.mod_group];
 
-    let mod_specs = profile
+    let mod_specs = mod_group
         .mods
         .iter()
         .filter_map(|config| config.enabled.then(|| config.spec.clone()))

--- a/src/state/config.rs
+++ b/src/state/config.rs
@@ -11,13 +11,11 @@ pub struct ConfigWrapper<C: Default + Serialize + DeserializeOwned> {
     path: PathBuf,
     config: C,
 }
+
 impl<C: Default + Serialize + DeserializeOwned> ConfigWrapper<C> {
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+    pub fn new<P: AsRef<Path>>(path: P, config: C) -> Self {
         Self {
-            config: std::fs::read(&path)
-                .ok()
-                .and_then(|s| serde_json::from_slice(&s).ok())
-                .unwrap_or_default(),
+            config,
             path: path.as_ref().to_path_buf(),
         }
     }

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -1,7 +1,9 @@
 pub mod config;
 
+use std::ops::DerefMut;
 use std::{
     collections::{BTreeMap, HashMap},
+    ops::Deref,
     path::PathBuf,
     sync::Arc,
 };
@@ -17,31 +19,121 @@ use crate::{
 
 use self::config::ConfigWrapper;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct ModData {
-    pub active_profile: String,
-    pub profiles: BTreeMap<String, ModProfile>,
-    pub active_group: String,
-    pub groups: BTreeMap<String, ModGroup>,
-}
-
-#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[obake::versioned]
+#[obake(version("0.0.0"))]
+#[obake(version("0.1.0"))]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ModProfile {
+    #[obake(cfg("0.0.0"))]
+    pub mods: Vec<ModConfig>,
+
     /// Mapping between mod groups and if they are enabled for a profile.
+    #[obake(cfg("0.1.0"))]
     pub mod_groups: IndexMap<String, bool>,
 }
 
-impl Default for ModProfile {
-    fn default() -> Self {
-        Self {
-            mod_groups: [("default".to_string(), false)].into(),
-        }
-    }
+#[obake::versioned]
+#[obake(version("0.0.0"))]
+#[obake(version("0.1.0"))]
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ModData {
+    pub active_profile: String,
+    #[obake(cfg("0.0.0"))]
+    pub profiles: BTreeMap<String, ModProfile!["0.0.0"]>,
+    #[obake(cfg("0.1.0"))]
+    pub profiles: BTreeMap<String, ModProfile!["0.1.0"]>,
+    #[obake(cfg("0.1.0"))]
+    pub active_group: String,
+    #[obake(cfg("0.1.0"))]
+    pub groups: BTreeMap<String, ModGroup>,
 }
 
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct ModGroup {
     pub mods: Vec<ModConfig>,
+}
+
+impl Default for ModData!["0.0.0"] {
+    fn default() -> Self {
+        Self {
+            active_profile: "default".to_string(),
+            profiles: [("default".to_string(), Default::default())]
+                .into_iter()
+                .collect(),
+        }
+    }
+}
+
+impl Default for ModData!["0.1.0"] {
+    fn default() -> Self {
+        Self {
+            active_profile: "default".to_string(),
+            profiles: [("default".to_string(), Default::default())]
+                .into_iter()
+                .collect(),
+            active_group: "default".to_string(),
+            groups: [("default".to_string(), Default::default())]
+                .into_iter()
+                .collect(),
+        }
+    }
+}
+
+impl From<ModData!["0.0.0"]> for ModData!["0.1.0"] {
+    fn from(legacy: ModData!["0.0.0"]) -> Self {
+        let mut new_mod_groups = Vec::new();
+        for (name, profile) in &legacy.profiles {
+            new_mod_groups.push((
+                name.clone(),
+                ModGroup {
+                    mods: profile.mods.clone(),
+                },
+            ));
+        }
+        let mut new_profiles = Vec::new();
+        for (name, _) in &legacy.profiles {
+            let mut mod_groups = Vec::new();
+            for (inner_name, _) in &legacy.profiles {
+                if name == inner_name {
+                    mod_groups.push((inner_name.clone(), true));
+                } else {
+                    mod_groups.push((inner_name.clone(), false));
+                }
+            }
+
+            new_profiles.push((
+                name.clone(),
+                ModProfile_v0_1_0 {
+                    mod_groups: mod_groups.into_iter().collect(),
+                },
+            ));
+        }
+
+        Self {
+            active_profile: legacy.active_profile.clone(),
+            profiles: new_profiles.into_iter().collect(),
+            active_group: legacy.active_profile,
+            groups: new_mod_groups.into_iter().collect(),
+        }
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "version")]
+pub enum VersionCheckedModData {
+    #[serde(rename = "0")]
+    Legacy(ModData!["0.0.0"]),
+    #[serde(rename = "1")]
+    V1(ModData!["0.1.0"]),
+    #[serde(other)]
+    Unsuppported,
+}
+
+impl From<ModProfile!["0.0.0"]> for ModProfile!["0.1.0"] {
+    fn from(_legacy: ModProfile!["0.0.0"]) -> Self {
+        // The migration requires `ModData` to handle instead.
+        unimplemented!("migration requires handling from `ModData`")
+    }
 }
 
 /// Mod configuration, holds ModSpecification as well as other metadata
@@ -58,27 +150,27 @@ fn default_true() -> bool {
     true
 }
 
-impl Default for ModData {
-    fn default() -> Self {
-        Self {
-            active_profile: "default".to_string(),
-            profiles: [("default".to_string(), Default::default())]
-                .into_iter()
-                .collect(),
-            active_group: "default".to_string(),
-            groups: [("default".to_string(), Default::default())]
-                .into_iter()
-                .collect(),
-        }
-    }
-}
-
-impl ModData {
-    pub fn get_active_profile(&self) -> &ModProfile {
+impl ModData!["0.0.0"] {
+    pub fn get_active_profile(&self) -> &ModProfile!["0.0.0"] {
         &self.profiles[&self.active_profile]
     }
 
-    pub fn get_active_profile_mut(&mut self) -> &mut ModProfile {
+    pub fn get_active_profile_mut(&mut self) -> &mut ModProfile!["0.0.0"] {
+        self.profiles.get_mut(&self.active_profile).unwrap()
+    }
+
+    pub fn remove_active_profile(&mut self) {
+        self.profiles.remove(&self.active_profile);
+        self.active_profile = self.profiles.keys().next().unwrap().to_string();
+    }
+}
+
+impl ModData!["0.1.0"] {
+    pub fn get_active_profile(&self) -> &ModProfile!["0.1.0"] {
+        &self.profiles[&self.active_profile]
+    }
+
+    pub fn get_active_profile_mut(&mut self) -> &mut ModProfile!["0.1.0"] {
         self.profiles.get_mut(&self.active_profile).unwrap()
     }
 
@@ -101,13 +193,59 @@ impl ModData {
     }
 }
 
+#[obake::versioned]
+#[obake(version("0.0.0"))]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Config {
     pub provider_parameters: HashMap<String, HashMap<String, String>>,
     pub drg_pak_path: Option<PathBuf>,
 }
 
-impl Default for Config {
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "version")]
+pub enum VersionAnnotatedConfig {
+    #[serde(rename = "0.0.0")]
+    V0_0_0(Config!["0.0.0"]),
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum MaybeVersionedConfig {
+    Legacy(Config!["0.0.0"]),
+    Versioned(VersionAnnotatedConfig),
+}
+
+impl Default for MaybeVersionedConfig {
+    fn default() -> Self {
+        MaybeVersionedConfig::Versioned(Default::default())
+    }
+}
+
+impl Default for VersionAnnotatedConfig {
+    fn default() -> Self {
+        VersionAnnotatedConfig::V0_0_0(Default::default())
+    }
+}
+
+impl Deref for VersionAnnotatedConfig {
+    type Target = Config!["0.0.0"];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            VersionAnnotatedConfig::V0_0_0(cfg) => cfg,
+        }
+    }
+}
+
+impl DerefMut for VersionAnnotatedConfig {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            VersionAnnotatedConfig::V0_0_0(cfg) => cfg,
+        }
+    }
+}
+
+impl Default for Config!["0.0.0"] {
     fn default() -> Self {
         Self {
             provider_parameters: Default::default(),
@@ -118,22 +256,110 @@ impl Default for Config {
     }
 }
 
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "version")]
+pub enum VersionAnnotatedModData {
+    #[serde(rename = "0.1.0")]
+    V0_1_0(ModData!["0.1.0"]),
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum MaybeVersionedModData {
+    Legacy(ModData!["0.0.0"]),
+    Versioned(VersionAnnotatedModData),
+}
+
+impl Default for MaybeVersionedModData {
+    fn default() -> Self {
+        MaybeVersionedModData::Versioned(Default::default())
+    }
+}
+
+impl Default for VersionAnnotatedModData {
+    fn default() -> Self {
+        VersionAnnotatedModData::V0_1_0(Default::default())
+    }
+}
+
+impl Deref for VersionAnnotatedModData {
+    type Target = ModData!["0.1.0"];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            VersionAnnotatedModData::V0_1_0(md) => md,
+        }
+    }
+}
+
+impl DerefMut for VersionAnnotatedModData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            VersionAnnotatedModData::V0_1_0(md) => md,
+        }
+    }
+}
+
 pub struct State {
     pub project_dirs: ProjectDirs,
-    pub config: ConfigWrapper<Config>,
-    pub mod_data: ConfigWrapper<ModData>,
+    pub config: ConfigWrapper<VersionAnnotatedConfig>,
+    pub mod_data: ConfigWrapper<VersionAnnotatedModData>,
     pub store: Arc<ModStore>,
 }
 
 impl State {
-    pub fn new() -> Result<Self> {
+    pub fn init() -> Result<Self> {
         let project_dirs = ProjectDirs::from("", "", "drg-mod-integration")
             .context("constructing project dirs")?;
         std::fs::create_dir_all(project_dirs.cache_dir())?;
         std::fs::create_dir_all(project_dirs.config_dir())?;
-        let config = ConfigWrapper::<Config>::new(project_dirs.config_dir().join("config.json"));
-        let mod_data =
-            ConfigWrapper::<ModData>::new(project_dirs.config_dir().join("mod_data.json"));
+        let config_path = project_dirs.config_dir().join("config.json");
+
+        let config = if config_path.exists() {
+            let config: MaybeVersionedConfig = std::fs::read(&config_path)
+                .ok()
+                .and_then(|s| serde_json::from_slice(&s).ok())
+                .unwrap_or_default();
+            let config = match config {
+                MaybeVersionedConfig::Versioned(v) => v,
+                MaybeVersionedConfig::Legacy(legacy) => {
+                    VersionAnnotatedConfig::V0_0_0(Config_v0_0_0 {
+                        provider_parameters: legacy.provider_parameters,
+                        drg_pak_path: legacy.drg_pak_path,
+                    })
+                }
+            };
+            ConfigWrapper::<VersionAnnotatedConfig>::new(&config_path, config)
+        } else {
+            ConfigWrapper::<VersionAnnotatedConfig>::new(&config_path, Default::default())
+        };
+        config.save().unwrap();
+
+        let legacy_mod_profiles_path = project_dirs.config_dir().join("profiles.json");
+        let mod_data_path = project_dirs.config_dir().join("mod_data.json");
+        let mod_data: MaybeVersionedModData = if mod_data_path.exists() {
+            std::fs::read(&mod_data_path)
+                .ok()
+                .and_then(|s| serde_json::from_slice(&s).ok())
+                .unwrap_or_default()
+        } else if legacy_mod_profiles_path.exists() {
+            let mod_data = std::fs::read(&legacy_mod_profiles_path)
+                .ok()
+                .and_then(|s| serde_json::from_slice(&s).ok())
+                .unwrap_or_default();
+            let _ = std::fs::remove_file(&legacy_mod_profiles_path);
+            mod_data
+        } else {
+            MaybeVersionedModData::default()
+        };
+
+        let mod_data = match mod_data {
+            MaybeVersionedModData::Legacy(legacy) => VersionAnnotatedModData::V0_1_0(legacy.into()),
+            MaybeVersionedModData::Versioned(v) => v,
+        };
+        let mod_data = ConfigWrapper::<VersionAnnotatedModData>::new(mod_data_path, mod_data);
+        mod_data.save().unwrap();
+
         let store = ModStore::new(project_dirs.cache_dir(), &config.provider_parameters)?.into();
         Ok(Self {
             project_dirs,


### PR DESCRIPTION
⚠️ **DEPRECATED: this PR will be superseded by a future PR** ⚠️

This PR migrates the conceptual model from the simple model of mod profiles simply containing mods to a more hierarchical model of mod profiles being composed of layered *mod groups*. Updating a *mod group* in turn updates all the mod profiles which depend on it. See #14 for more context.

It also implements versioned configuration files (`config.json`, `profiles.json` -> `mod_data.json`, `cache.json`) and their migration.

### Pending Work

- [x] Add drag-and-drop move support for the profiles so the contained mod profiles can be reordered to adjust load order.
- [x] Add some explanation to the new model.
- [x] Handle config file versioning and migration (`config.json`, `profiles.json` -> `mod_data.json`, `cache.json`). **NEEDS TESTING**.

### Future Work

- Migrate from side-by-side panel to floating windows.
