### PR TITLE
Add versioned config and migrations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1121,6 +1121,7 @@ dependencies = [
  "inventory",
  "lazy_static",
  "modio",
+ "obake",
  "opener",
  "regex",
  "repak",
@@ -2519,6 +2520,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.27",
+]
+
+[[package]]
+name = "obake"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c016d34f5be5713bfcaa23668b736865921606c2ddff17e158f0815e4cde091b"
+dependencies = [
+ "obake_macros",
+]
+
+[[package]]
+name = "obake_macros"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47056b8eb01b867a9fdc29f69c05799b9eafb50f73e440cafe624949e27cc7dc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "semver",
+ "syn 1.0.109",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ image = { version = "0.24.6", default-features = false, features = ["png"] }
 inventory = "0.3.6"
 lazy_static = "1.4.0"
 modio = { version = "0.7.1", features = ["rustls-tls"] }
+obake = { version = "1.0.5", features = ["serde"] }
 opener = "0.6.1"
 regex = "1.8.3"
 repak = { git = "https://github.com/trumank/repak.git", version = "0.1.3" }

--- a/src/gui/message.rs
+++ b/src/gui/message.rs
@@ -93,7 +93,7 @@ impl ResolveMods {
         if Some(self.rid) == app.resolve_mod_rid.as_ref().map(|r| r.rid) {
             match self.result {
                 Ok(resolved_mods) => {
-                    let profile = app.state.profiles.get_active_profile_mut();
+                    let profile = app.state.mod_data.get_active_profile_mut();
                     let primary_mods = self
                         .specs
                         .into_iter()
@@ -128,7 +128,7 @@ impl ResolveMods {
                         }
                     }
                     app.resolve_mod.clear();
-                    app.state.profiles.save().unwrap();
+                    app.state.mod_data.save().unwrap();
                     app.last_action_status =
                         LastActionStatus::Success("mods successfully resolved".to_string());
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![feature(let_chains)]
+
 pub mod error;
 pub mod gui;
 pub mod integrate;

--- a/src/main.rs
+++ b/src/main.rs
@@ -138,7 +138,7 @@ async fn action_integrate(action: ActionIntegrate) -> Result<()> {
         })
         .context("Could not find DRG pak file, please specify manually with the --fsd_pak flag")?;
 
-    let mut state = State::new()?;
+    let mut state = State::init()?;
 
     let mod_specs = action
         .mods
@@ -166,8 +166,8 @@ async fn action_integrate_profile(action: ActionIntegrateProfile) -> Result<()> 
         })
         .context("Could not find DRG pak file, please specify manually with the --fsd_pak flag")?;
 
-    let mut state = State::new()?;
-    let profile = &state.profiles.profiles[&action.profile];
+    let mut state = State::init()?;
+    let profile = &state.mod_data.profiles[&action.profile];
 
     let mod_specs = profile
         .mods

--- a/src/providers/mod.rs
+++ b/src/providers/mod.rs
@@ -14,17 +14,71 @@ use tokio::sync::mpsc::Sender;
 use std::collections::{BTreeSet, HashMap, HashSet};
 
 use std::io::{Read, Seek};
+use std::ops::{Deref, DerefMut};
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, RwLock};
 
 type Providers = RwLock<HashMap<&'static str, Arc<dyn ModProvider>>>;
-pub type ProviderCache = Arc<RwLock<ConfigWrapper<Cache>>>;
+
+pub type ProviderCache = Arc<RwLock<ConfigWrapper<VersionAnnotatedCache>>>;
+
+#[obake::versioned]
+#[obake(version("0.0.0"))]
+#[derive(Debug, Default, Serialize, Deserialize)]
+pub struct Cache {
+    cache: HashMap<String, Box<dyn ModProviderCache>>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(tag = "version")]
+pub enum VersionAnnotatedCache {
+    #[serde(rename = "0.0.0")]
+    V0_0_0(Cache!["0.0.0"]),
+}
+
+impl Default for VersionAnnotatedCache {
+    fn default() -> Self {
+        VersionAnnotatedCache::V0_0_0(Default::default())
+    }
+}
+
+impl Deref for VersionAnnotatedCache {
+    type Target = Cache!["0.0.0"];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            VersionAnnotatedCache::V0_0_0(c) => c,
+        }
+    }
+}
+
+impl DerefMut for VersionAnnotatedCache {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            VersionAnnotatedCache::V0_0_0(c) => c,
+        }
+    }
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum MaybeVersionedCache {
+    Versioned(VersionAnnotatedCache),
+    Legacy(Cache!["0.0.0"]),
+}
+
+impl Default for MaybeVersionedCache {
+    fn default() -> Self {
+        MaybeVersionedCache::Versioned(Default::default())
+    }
+}
 
 pub struct ModStore {
     providers: Providers,
     cache: ProviderCache,
     blob_cache: BlobCache,
 }
+
 impl ModStore {
     pub fn new<P: AsRef<Path>>(
         cache_path: P,
@@ -40,11 +94,55 @@ impl ModStore {
             })
             .collect::<Result<HashMap<_, _>>>()?;
 
+        let cache_metadata_path = cache_path.as_ref().join("cache.json");
+        let cache: MaybeVersionedCache = std::fs::read(&cache_metadata_path)
+                .ok()
+                .and_then(|s| {
+                    let Ok(mut v) = serde_json::from_slice::<serde_json::Value>(&s) else {
+                        return None;
+                    };
+                    let Some(obj_map) = v.as_object_mut() else {
+                        return None;
+                    };
+                    let version = obj_map.remove("version");
+
+                    if let Some(v) = version && let serde_json::Value::String(vs) = v
+                    {
+                        match vs.as_str() {
+                            "0.0.0" => {
+                                // HACK: workaround a serde issue relating to flattening with tags
+                                // involving numeric keys in hashmaps, see
+                                // <https://github.com/serde-rs/serde/issues/1183>.
+                                if let Ok(c) = serde_json::from_slice::<Cache!["0.0.0"]>(&s)
+                                {
+                                    return Some(MaybeVersionedCache::Versioned(VersionAnnotatedCache::V0_0_0(c)));
+                                }
+                            }
+                            _ => unimplemented!(),
+                        }
+                    } else {
+                        // HACK: workaround a serde issue relating to flattening with tags involving
+                        // numeric keys in hashmaps, see <https://github.com/serde-rs/serde/issues/1183>.
+                        if let Ok(c) =
+                            serde_json::from_slice::<HashMap<String, Box<dyn ModProviderCache>>>(&s)
+                        {
+                            return Some(MaybeVersionedCache::Legacy(Cache_v0_0_0 { cache: c }));
+                        }
+                    }
+
+                    None
+                })
+                .unwrap_or_default();
+        let cache: VersionAnnotatedCache = match cache {
+            MaybeVersionedCache::Versioned(c) => c,
+            MaybeVersionedCache::Legacy(legacy) => VersionAnnotatedCache::V0_0_0(legacy),
+        };
+        let cache = ConfigWrapper::new(&cache_metadata_path, cache);
+        cache.save().unwrap();
+
         Ok(Self {
             providers: RwLock::new(providers),
-            cache: Arc::new(RwLock::new(ConfigWrapper::new(
-                cache_path.as_ref().join("cache.json"),
-            ))),
+            cache: Arc::new(RwLock::new(cache)),
             blob_cache: BlobCache::new(cache_path.as_ref().join("blobs")),
         })
     }
@@ -282,6 +380,7 @@ pub enum ModResponse {
 pub struct ModSpecification {
     pub url: String,
 }
+
 impl ModSpecification {
     pub fn new(url: String) -> Self {
         Self { url }
@@ -298,6 +397,7 @@ pub struct ModResolution {
     pub url: String,
     pub status: ResolvableStatus,
 }
+
 impl ModResolution {
     fn resolvable(url: String) -> Self {
         Self {
@@ -372,23 +472,25 @@ pub trait ModProviderCache: Sync + Send + std::fmt::Debug {
     fn as_any_mut(&mut self) -> &mut dyn std::any::Any;
 }
 
-#[derive(Debug, Default, Serialize, Deserialize)]
-pub struct Cache(HashMap<String, Box<dyn ModProviderCache>>);
 impl Cache {
     fn has<T: ModProviderCache + 'static>(&self, id: &str) -> bool {
-        self.0
+        self.cache
             .get(id)
             .and_then(|c| c.as_any().downcast_ref::<T>())
             .is_none()
     }
+
     fn get<T: ModProviderCache + 'static>(&self, id: &str) -> Option<&T> {
-        self.0.get(id).and_then(|c| c.as_any().downcast_ref::<T>())
+        self.cache
+            .get(id)
+            .and_then(|c| c.as_any().downcast_ref::<T>())
     }
+
     fn get_mut<T: ModProviderCache + 'static>(&mut self, id: &str) -> &mut T {
         if self.has::<T>(id) {
-            self.0.insert(id.to_owned(), Box::new(T::new()));
+            self.cache.insert(id.to_owned(), Box::new(T::new()));
         }
-        self.0
+        self.cache
             .get_mut(id)
             .and_then(|c| c.as_any_mut().downcast_mut::<T>())
             .unwrap()
@@ -402,6 +504,7 @@ pub struct BlobRef(String);
 pub struct BlobCache {
     path: PathBuf,
 }
+
 impl BlobCache {
     fn new<P: AsRef<Path>>(path: P) -> Self {
         std::fs::create_dir(&path).ok();
@@ -409,6 +512,7 @@ impl BlobCache {
             path: path.as_ref().to_path_buf(),
         }
     }
+
     fn write(&self, blob: &[u8]) -> Result<BlobRef> {
         use sha2::{Digest, Sha256};
 
@@ -422,6 +526,7 @@ impl BlobCache {
 
         Ok(BlobRef(hash))
     }
+
     fn get_path(&self, blob: &BlobRef) -> Option<PathBuf> {
         let path = self.path.join(&blob.0);
         path.exists().then_some(path)

--- a/src/state/config.rs
+++ b/src/state/config.rs
@@ -11,13 +11,11 @@ pub struct ConfigWrapper<C: Default + Serialize + DeserializeOwned> {
     path: PathBuf,
     config: C,
 }
+
 impl<C: Default + Serialize + DeserializeOwned> ConfigWrapper<C> {
-    pub fn new<P: AsRef<Path>>(path: P) -> Self {
+    pub fn new<P: AsRef<Path>>(path: P, config: C) -> Self {
         Self {
-            config: std::fs::read(&path)
-                .ok()
-                .and_then(|s| serde_json::from_slice(&s).ok())
-                .unwrap_or_default(),
+            config,
             path: path.as_ref().to_path_buf(),
         }
     }
@@ -26,17 +24,20 @@ impl<C: Default + Serialize + DeserializeOwned> ConfigWrapper<C> {
         Ok(())
     }
 }
+
 impl<C: Default + Serialize + DeserializeOwned> std::ops::Deref for ConfigWrapper<C> {
     type Target = C;
     fn deref(&self) -> &Self::Target {
         &self.config
     }
 }
+
 impl<C: Default + Serialize + DeserializeOwned> std::ops::DerefMut for ConfigWrapper<C> {
     fn deref_mut(&mut self) -> &mut C {
         &mut self.config
     }
 }
+
 impl<C: Default + Serialize + DeserializeOwned> Drop for ConfigWrapper<C> {
     fn drop(&mut self) {
         self.save().unwrap();

--- a/src/state/mod.rs
+++ b/src/state/mod.rs
@@ -2,6 +2,7 @@ pub mod config;
 
 use std::{
     collections::{BTreeMap, HashMap},
+    ops::{Deref, DerefMut},
     path::PathBuf,
     sync::Arc,
 };
@@ -16,17 +17,6 @@ use crate::{
 
 use self::config::ConfigWrapper;
 
-#[derive(serde::Serialize, serde::Deserialize)]
-pub struct ModProfiles {
-    pub active_profile: String,
-    pub profiles: BTreeMap<String, ModProfile>,
-}
-
-#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
-pub struct ModProfile {
-    pub mods: Vec<ModConfig>,
-}
-
 /// Mod configuration, holds ModSpecification as well as other metadata
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct ModConfig {
@@ -36,11 +26,43 @@ pub struct ModConfig {
     #[serde(default = "default_true")]
     pub enabled: bool,
 }
+
 fn default_true() -> bool {
     true
 }
 
-impl Default for ModProfiles {
+#[obake::versioned]
+#[obake(version("0.0.0"))]
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct ModProfile {
+    #[obake(cfg("0.0.0"))]
+    pub mods: Vec<ModConfig>,
+}
+
+#[obake::versioned]
+#[obake(version("0.0.0"))]
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct ModData {
+    pub active_profile: String,
+    #[obake(cfg("0.0.0"))]
+    pub profiles: BTreeMap<String, ModProfile!["0.0.0"]>,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "version")]
+pub enum VersionAnnotatedModData {
+    #[serde(rename = "0.0.0")]
+    V0_0_0(ModData!["0.0.0"]),
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum MaybeVersionedModData {
+    Versioned(VersionAnnotatedModData),
+    Legacy(ModData!["0.0.0"]),
+}
+
+impl Default for ModData!["0.0.0"] {
     fn default() -> Self {
         Self {
             active_profile: "default".to_string(),
@@ -51,26 +73,108 @@ impl Default for ModProfiles {
     }
 }
 
-impl ModProfiles {
+impl Default for MaybeVersionedModData {
+    fn default() -> Self {
+        MaybeVersionedModData::Versioned(Default::default())
+    }
+}
+
+impl Default for VersionAnnotatedModData {
+    fn default() -> Self {
+        VersionAnnotatedModData::V0_0_0(Default::default())
+    }
+}
+
+impl Deref for VersionAnnotatedModData {
+    type Target = ModData!["0.0.0"];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            VersionAnnotatedModData::V0_0_0(md) => md,
+        }
+    }
+}
+
+impl DerefMut for VersionAnnotatedModData {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            VersionAnnotatedModData::V0_0_0(md) => md,
+        }
+    }
+}
+
+impl ModData!["0.0.0"] {
     pub fn get_active_profile(&self) -> &ModProfile {
         &self.profiles[&self.active_profile]
     }
+
     pub fn get_active_profile_mut(&mut self) -> &mut ModProfile {
         self.profiles.get_mut(&self.active_profile).unwrap()
     }
-    pub fn remove_active(&mut self) {
+
+    pub fn remove_active_profile(&mut self) {
         self.profiles.remove(&self.active_profile);
         self.active_profile = self.profiles.keys().next().unwrap().to_string();
     }
 }
 
+#[obake::versioned]
+#[obake(version("0.0.0"))]
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
 pub struct Config {
     pub provider_parameters: HashMap<String, HashMap<String, String>>,
     pub drg_pak_path: Option<PathBuf>,
 }
 
-impl Default for Config {
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "version")]
+pub enum VersionAnnotatedConfig {
+    #[serde(rename = "0.0.0")]
+    V0_0_0(Config!["0.0.0"]),
+    #[serde(other)]
+    Unsupported,
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+#[serde(untagged)]
+pub enum MaybeVersionedConfig {
+    Versioned(VersionAnnotatedConfig),
+    Legacy(Config!["0.0.0"]),
+}
+
+impl Default for MaybeVersionedConfig {
+    fn default() -> Self {
+        MaybeVersionedConfig::Versioned(Default::default())
+    }
+}
+
+impl Default for VersionAnnotatedConfig {
+    fn default() -> Self {
+        VersionAnnotatedConfig::V0_0_0(Default::default())
+    }
+}
+
+impl Deref for VersionAnnotatedConfig {
+    type Target = Config!["0.0.0"];
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            VersionAnnotatedConfig::V0_0_0(cfg) => cfg,
+            VersionAnnotatedConfig::Unsupported => unreachable!(),
+        }
+    }
+}
+
+impl DerefMut for VersionAnnotatedConfig {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            VersionAnnotatedConfig::V0_0_0(cfg) => cfg,
+            VersionAnnotatedConfig::Unsupported => unreachable!(),
+        }
+    }
+}
+
+impl Default for Config!["0.0.0"] {
     fn default() -> Self {
         Self {
             provider_parameters: Default::default(),
@@ -83,25 +187,71 @@ impl Default for Config {
 
 pub struct State {
     pub project_dirs: ProjectDirs,
-    pub config: ConfigWrapper<Config>,
-    pub profiles: ConfigWrapper<ModProfiles>,
+    pub config: ConfigWrapper<VersionAnnotatedConfig>,
+    pub mod_data: ConfigWrapper<VersionAnnotatedModData>,
     pub store: Arc<ModStore>,
 }
 
 impl State {
-    pub fn new() -> Result<Self> {
+    pub fn init() -> Result<Self> {
         let project_dirs = ProjectDirs::from("", "", "drg-mod-integration")
             .context("constructing project dirs")?;
         std::fs::create_dir_all(project_dirs.cache_dir())?;
         std::fs::create_dir_all(project_dirs.config_dir())?;
-        let config = ConfigWrapper::<Config>::new(project_dirs.config_dir().join("config.json"));
-        let profiles =
-            ConfigWrapper::<ModProfiles>::new(project_dirs.config_dir().join("profiles.json"));
+
+        let config_path = project_dirs.config_dir().join("config.json");
+
+        let config = if config_path.exists() {
+            let config: MaybeVersionedConfig = std::fs::read(&config_path)
+                .ok()
+                .and_then(|s| serde_json::from_slice(&s).ok())
+                .unwrap_or_default();
+            let config = match config {
+                MaybeVersionedConfig::Versioned(v) => v,
+                MaybeVersionedConfig::Legacy(legacy) => {
+                    VersionAnnotatedConfig::V0_0_0(Config_v0_0_0 {
+                        provider_parameters: legacy.provider_parameters,
+                        drg_pak_path: legacy.drg_pak_path,
+                    })
+                }
+            };
+            ConfigWrapper::<VersionAnnotatedConfig>::new(&config_path, config)
+        } else {
+            ConfigWrapper::<VersionAnnotatedConfig>::new(&config_path, Default::default())
+        };
+        config.save().unwrap();
+
+        let legacy_mod_profiles_path = project_dirs.config_dir().join("profiles.json");
+        let mod_data_path = project_dirs.config_dir().join("mod_data.json");
+        let mod_data: MaybeVersionedModData = if mod_data_path.exists() {
+            std::fs::read(&mod_data_path)
+                .ok()
+                .and_then(|s| serde_json::from_slice(&s).ok())
+                .unwrap_or_default()
+        } else if legacy_mod_profiles_path.exists() {
+            let mod_data = std::fs::read(&legacy_mod_profiles_path)
+                .ok()
+                .and_then(|s| serde_json::from_slice(&s).ok())
+                .unwrap_or_default();
+            let _ = std::fs::remove_file(&legacy_mod_profiles_path);
+            mod_data
+        } else {
+            MaybeVersionedModData::default()
+        };
+
+        let mod_data = match mod_data {
+            MaybeVersionedModData::Legacy(legacy) => VersionAnnotatedModData::V0_0_0(legacy),
+            MaybeVersionedModData::Versioned(v) => v,
+        };
+        let mod_data = ConfigWrapper::<VersionAnnotatedModData>::new(mod_data_path, mod_data);
+        mod_data.save().unwrap();
+
         let store = ModStore::new(project_dirs.cache_dir(), &config.provider_parameters)?.into();
+
         Ok(Self {
             project_dirs,
             config,
-            profiles,
+            mod_data,
             store,
         })
     }


### PR DESCRIPTION
- Versions `config`, `profiles` -> `mod_data`, `cache` to 0.0.0 each.
- Implements migrations from legacy unversioned config/profiles/cache to versioned.