### PR TITLE
Make config writes more likely to be complete

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1181,6 +1181,7 @@ dependencies = [
  "sha2",
  "steamlocate",
  "task-local-extensions",
+ "tempfile",
  "thiserror",
  "tokio",
  "tracing",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ serde_json = "1.0.104"
 sha2 = "0.10.7"
 steamlocate = "2.0.0-alpha.0"
 task-local-extensions = "0.1.4"
+tempfile = "3.7.1"
 thiserror = "1.0.44"
 tokio = { version = "1.31.0", features = ["full"] }
 tracing = { version = "0.1.37", features = ["attributes"] }


### PR DESCRIPTION
To better protect against partial/corrupted configs. This is best-effort as there is no perfect way to guarantee atomic fs writes in the general case. This PR tries to improve the reliability config writes by:

- Writing the config to a temp file in the same filesystem (read: same directory) as the target file.
- Renaming the temp file to the target file effectively replacing the original file.

This way, even if the tool crashes / is killed mid write, the worst we get is most likely a broken/partial temp file and the user loses their most recent changes, instead of completely bricking entire profiles/mod data/cache JSONs.