### PR TITLE
Enable console ANSI code support on Windows 10

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -188,6 +188,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ansi_term"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52a9bb7ec0cf484c551830a7ce27bd20d67eac647e1befb56b0be4ee39a55d2"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1149,6 +1158,7 @@ checksum = "9ea835d29036a4087793836fa931b08837ad5e957da9e23886b29586fb9b6650"
 name = "drg_mod_integration"
 version = "0.2.9"
 dependencies = [
+ "ansi_term",
  "anyhow",
  "async-trait",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 repository = "https://github.com/trumank/drg-mod-integration"
 
 [dependencies]
+ansi_term = "0.12.1"
 anyhow = { version = "1.0.72", features = ["backtrace"] }
 async-trait = "0.1.73"
 clap = { version = "4.3.21", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -95,6 +95,13 @@ struct Args {
 }
 
 fn main() -> Result<()> {
+    #[cfg(target_os = "windows")]
+    {
+        // Try to enable ANSI code support on Windows 10 for console. If it fails, then whatever
+        // *shrugs*.
+        let _res = ansi_term::enable_ansi_support();
+    }
+
     std::env::set_var("RUST_BACKTRACE", "1");
     let _guard = setup_logging()?;
     debug!("logging setup complete");


### PR DESCRIPTION
If the user is using Windows Console Host as their default console on Windows 10, then this should enable ANSI code support for them.