### PR TITLE
Fix mod.io 403 error caused by API changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -331,7 +331,7 @@ version = "0.38.0+1.3.281"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bb44936d800fea8f016d7f2311c6a4f97aebd5dc86f09906139ec848cf3a46f"
 dependencies = [
- "libloading",
+ "libloading 0.8.1",
 ]
 
 [[package]]
@@ -924,7 +924,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1388,7 +1388,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "330c60081dcc4c72131f8eb70510f1ac07223e5d4163db481a04a0befcffa412"
 dependencies = [
- "libloading",
+ "libloading 0.8.1",
 ]
 
 [[package]]
@@ -1875,12 +1875,12 @@ checksum = "27573eac26f4dd11e2b1916c3fe1baa56407c83c71a773a8ba17ec0bca03b6b7"
 
 [[package]]
 name = "flate2"
-version = "1.0.34"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1b589b4dc103969ad3cf85c950899926ec64300a1a46d76c03a6072957036f0"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.0",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -2192,7 +2192,7 @@ dependencies = [
  "glutin_egl_sys",
  "glutin_glx_sys",
  "glutin_wgl_sys",
- "libloading",
+ "libloading 0.8.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -2571,7 +2571,7 @@ dependencies = [
  "http 1.1.0",
  "hyper 1.1.0",
  "hyper-util",
- "rustls 0.23.16",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls 0.26.0",
@@ -3024,7 +3024,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6aae1df220ece3c0ada96b8153459b67eebe9ae9212258bb0134ae60416fdf76"
 dependencies = [
  "libc",
- "libloading",
+ "libloading 0.8.1",
  "pkg-config",
 ]
 
@@ -3076,6 +3076,16 @@ checksum = "c571b676ddfc9a8c12f1f3d3085a7b163966a8fd8098a90640953ce5f6170161"
 dependencies = [
  "cfg-if",
  "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "libloading"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -3153,9 +3163,18 @@ checksum = "9374ef4228402d4b7e403e5838cb880d9ee663314b0a900d5a6aabf0c213552e"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+
+[[package]]
+name = "lz4_flex"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90071f8077f8e40adfc4b7fe9cd495ce316263f19e75c2211eeff3fdf475a3d9"
+dependencies = [
+ "twox-hash 2.1.2",
+]
 
 [[package]]
 name = "mach"
@@ -3269,9 +3288,9 @@ dependencies = [
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.0"
+version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2d80299ef12ff69b16a84bb182e3b9df68b5a91574d3d4fa6e41b65deec4df1"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3324,7 +3343,7 @@ dependencies = [
  "strum 0.27.1",
  "task-local-extensions",
  "tempfile",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "tokio",
  "tracing",
  "typetag",
@@ -3448,7 +3467,7 @@ dependencies = [
  "spirv",
  "strum 0.26.3",
  "termcolor",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "unicode-xid",
 ]
 
@@ -3923,6 +3942,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
+name = "oodle_loader"
+version = "0.2.3"
+source = "git+https://github.com/trumank/repak#355b5f62f51959c7cc6dd5a51708646ef483065d"
+dependencies = [
+ "hex",
+ "libloading 0.9.0",
+ "sha2",
+ "thiserror 2.0.18",
+ "ureq",
+]
+
+[[package]]
 name = "opener"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4202,7 +4233,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.0",
+ "miniz_oxide 0.8.9",
 ]
 
 [[package]]
@@ -4388,7 +4419,7 @@ dependencies = [
  "quinn-proto",
  "quinn-udp",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.41",
  "socket2 0.5.5",
  "thiserror 1.0.66",
  "tokio",
@@ -4405,7 +4436,7 @@ dependencies = [
  "rand 0.8.5",
  "ring",
  "rustc-hash 2.0.0",
- "rustls 0.23.16",
+ "rustls 0.23.41",
  "slab",
  "thiserror 1.0.66",
  "tinyvec",
@@ -4550,7 +4581,7 @@ checksum = "dd6f9d3d47bdd2ad6945c5015a226ec6155d0bcdfd8f7cd29f86b71f8de99d2b"
 dependencies = [
  "getrandom 0.2.11",
  "libredox 0.1.3",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -4617,15 +4648,18 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "repak"
-version = "0.2.1"
-source = "git+https://github.com/trumank/repak#96410d664ac46c87cf451a3c5bad38d8cf42dda5"
+version = "0.2.3"
+source = "git+https://github.com/trumank/repak#355b5f62f51959c7cc6dd5a51708646ef483065d"
 dependencies = [
  "aes",
  "byteorder",
  "flate2",
+ "hex",
+ "lz4_flex",
+ "oodle_loader",
  "sha1",
- "strum 0.24.1",
- "thiserror 1.0.66",
+ "strum 0.27.1",
+ "thiserror 2.0.18",
  "zstd",
 ]
 
@@ -4699,7 +4733,7 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "quinn",
- "rustls 0.23.16",
+ "rustls 0.23.41",
  "rustls-pemfile 2.2.0",
  "rustls-pki-types",
  "serde",
@@ -4863,14 +4897,15 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.16"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",
- "rustls-webpki 0.102.8",
+ "rustls-webpki 0.103.13",
  "subtle",
  "zeroize",
 ]
@@ -4895,9 +4930,12 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.10.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+checksum = "764899a24af3980067ee14bc143654f297b22eaebfe3c7b6b211920a5a59b046"
+dependencies = [
+ "zeroize",
+]
 
 [[package]]
 name = "rustls-webpki"
@@ -4911,9 +4949,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.102.8"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4934,7 +4972,7 @@ checksum = "58c4eb8a81997cf040a091d1f7e1938aeab6749d3a0dfa73af43cdc32393483d"
 dependencies = [
  "byteorder",
  "derive_more",
- "twox-hash",
+ "twox-hash 1.6.3",
 ]
 
 [[package]]
@@ -5275,7 +5313,7 @@ version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5fd9e3263fc19d73abd5107dbd4d43e37949212d2b15d4d334ee5db53022b8"
 dependencies = [
- "heck 0.5.0",
+ "heck 0.4.1",
  "proc-macro2",
  "quote",
  "syn 2.0.87",
@@ -5388,15 +5426,6 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.24.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063e6045c0e62079840579a7e47a355ae92f60eb74daaf156fb1e84ba164e63f"
-dependencies = [
- "strum_macros 0.24.3",
-]
-
-[[package]]
-name = "strum"
 version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "290d54ea6f91c969195bdbcd7442c8c2a2ba87da8bf60a7ee86a235d4bc1e125"
@@ -5420,19 +5449,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f64def088c51c9510a8579e3c5d67c65349dcf755e5479ad3d010aa6454e2c32"
 dependencies = [
  "strum_macros 0.27.1",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.24.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e385be0d24f186b4ce2f9982191e7101bb737312ad61c1f2f984f34bcf85d59"
-dependencies = [
- "heck 0.4.1",
- "proc-macro2",
- "quote",
- "rustversion",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -5603,11 +5619,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3467d614147380f2e4e374161426ff399c91084acd2363eaf549172b3d5e60c0"
+checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl 2.0.16",
+ "thiserror-impl 2.0.18",
 ]
 
 [[package]]
@@ -5623,9 +5639,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.16"
+version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5e1be1c48b9172ee610da68fd9cd2770e7a4056cb3fc98710ee6906f0c7960"
+checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5790,7 +5806,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
 dependencies = [
- "rustls 0.23.16",
+ "rustls 0.23.41",
  "rustls-pki-types",
  "tokio",
 ]
@@ -5966,6 +5982,12 @@ dependencies = [
  "cfg-if",
  "static_assertions",
 ]
+
+[[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
 
 [[package]]
 name = "type-map"
@@ -6200,6 +6222,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls 0.23.41",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+ "webpki-roots 1.0.8",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.1.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6222,6 +6273,12 @@ name = "utf16_iter"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -6533,6 +6590,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-roots"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "weezl"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6583,7 +6649,7 @@ dependencies = [
  "raw-window-handle",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "wgpu-hal",
  "wgpu-types",
 ]
@@ -6608,7 +6674,7 @@ dependencies = [
  "js-sys",
  "khronos-egl",
  "libc",
- "libloading",
+ "libloading 0.8.1",
  "log",
  "metal",
  "naga",
@@ -6622,7 +6688,7 @@ dependencies = [
  "renderdoc-sys",
  "rustc-hash 1.1.0",
  "smallvec",
- "thiserror 2.0.16",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "web-sys",
  "wgpu-types",
@@ -6716,7 +6782,7 @@ dependencies = [
  "windows-collections",
  "windows-core 0.61.2",
  "windows-future",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-numerics",
 ]
 
@@ -6768,7 +6834,7 @@ checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
 dependencies = [
  "windows-implement 0.60.0",
  "windows-interface 0.59.1",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-result 0.3.4",
  "windows-strings 0.4.2",
 ]
@@ -6780,7 +6846,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
  "windows-threading",
 ]
 
@@ -6835,13 +6901,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
 
 [[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6870,7 +6942,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6889,7 +6961,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -6980,7 +7052,7 @@ version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
 dependencies = [
- "windows-link",
+ "windows-link 0.1.3",
 ]
 
 [[package]]
@@ -7268,7 +7340,7 @@ dependencies = [
  "as-raw-xcb-connection",
  "gethostname 0.4.3",
  "libc",
- "libloading",
+ "libloading 0.8.1",
  "once_cell",
  "rustix 0.38.38",
  "x11rb-protocol 0.13.0",
@@ -7668,28 +7740,27 @@ dependencies = [
 
 [[package]]
 name = "zstd"
-version = "0.12.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a27595e173641171fc74a1232b7b1c7a7cb6e18222c11e9dfb9888fa424c53c"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
 dependencies = [
  "zstd-safe",
 ]
 
 [[package]]
 name = "zstd-safe"
-version = "6.0.6"
+version = "7.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee98ffd0b48ee95e6c5168188e44a54550b1564d9d530ee21d5f0eaed1069581"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
 dependencies = [
- "libc",
  "zstd-sys",
 ]
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.9+zstd.1.5.5"
+version = "2.0.16+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e16efa8a874a0481a574084d34cc26fdb3b99627480f785888deb6386506656"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
 dependencies = [
  "cc",
  "pkg-config",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ edition = "2024"
 anyhow = { version = "1.0.99", features = ["backtrace"] }
 patternsleuth = { git = "https://github.com/trumank/patternsleuth" }
 steamlocate = "2.0.1"
-repak = { git = "https://github.com/trumank/repak" }
+repak = { git = "https://github.com/trumank/repak", features = ["oodle"] }
 serde = { version = "1.0.219", features = ["derive"] }
 serde_json = "1.0.143"
 itertools = "0.14.0"

--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-Fixed the mod.io 403 issue. If you'd rather patch the original repository yourself, follow these steps:
-- Clone the MINT repository and open src\providers\modio.rs.
-- Replace:
-use modio::filter::{Eq, In};
-use modio::mods::filters::{NameId, Visible};
-with:
-use modio::filter::Eq;
-use modio::mods::filters::NameId;
-- Replace:
-let filter = NameId::eq(name_id).and(Visible::_in(vec![0, 1]));
-with:
-let filter = NameId::eq(name_id);
--Build MINT
-
-
 # mint
 
 3rd party mod integration tool for Deep Rock Galactic to download and integrate mods completely

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@ This version of Mint fixes two issues:
 
 - Fixes the mod.io API 403 error.
 - Limits the mission selector/server browser mod list to 100 entries, preventing hosting/invites from breaking when the mission selector mod list string becomes too large.
+- Updated Trumans Repaker to make mods that need oodle compression work again automatically without needing to manually add a DLL (for example: https://mod.io/g/drg/m/missions-hud)
 
 If you'd like to build it yourself from the original mint-repo, take a look at my commits to see the fixes I implemented.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
+This version of Mint fixes two issues:
+
+- Fixes the mod.io API 403 error.
+- Limits the mission selector/server browser mod list to 100 entries, preventing hosting/invites from breaking when the mission selector mod list string becomes too large.
+
+If you'd like to build it yourself from the original mint-repo, take a look at my commits to see the fixes I implemented.
+
 # mint
 
 3rd party mod integration tool for Deep Rock Galactic to download and integrate mods completely

--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
+Fixed the mod.io 403 issue. If you'd rather patch the original repository yourself, follow these steps:
+- Clone the MINT repository and open src\providers\modio.rs.
+- Replace:
+use modio::filter::{Eq, In};
+use modio::mods::filters::{NameId, Visible};
+with:
+use modio::filter::Eq;
+use modio::mods::filters::NameId;
+- Replace:
+let filter = NameId::eq(name_id).and(Visible::_in(vec![0, 1]));
+with:
+let filter = NameId::eq(name_id);
+-Build MINT
+
+
 # mint
 
 3rd party mod integration tool for Deep Rock Galactic to download and integrate mods completely

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-This version of Mint fixes two issues:
-
-- Fixes the mod.io API 403 error.
+This version of Mint fixes these issues:
+- Fixed HTTP 403 errors (mod lookup) by removing the deprecated `visible` filter from mod.io API requests.
+- Fixed HTTP 403 errors by replacing direct mod file metadata requests (`GET /mods/{id}/files/{file_id}`) with filtered list queries, restoring mod downloads.
 - Limits the mission selector/server browser mod list to 100 entries, preventing hosting/invites from breaking when the mission selector mod list string becomes too large.
 - Updated Trumans Repaker to make mods that need oodle compression work again automatically without needing to manually add a DLL (for example: https://mod.io/g/drg/m/missions-hud)
 

--- a/mint_lib/src/mod_info.rs
+++ b/mint_lib/src/mod_info.rs
@@ -151,6 +151,7 @@ impl Meta {
                 self.mods
                     .iter()
                     .sorted_by_key(|m| (std::cmp::Reverse(m.approval), &m.name))
+                    .take(100)
                     .flat_map(|m| {
                         [
                             match m.approval {

--- a/src/integrate.rs
+++ b/src/integrate.rs
@@ -580,7 +580,7 @@ impl<W: Write + Seek> ModBundleWriter<W> {
 
     fn write_file(&mut self, data: &[u8], path: &str) -> Result<(), IntegrationError> {
         self.pak_writer
-            .write_file(self.normalize_path(path).as_str(), data)?;
+            .write_file(self.normalize_path(path).as_str(), false, data)?;
         Ok(())
     }
 

--- a/src/providers/modio.rs
+++ b/src/providers/modio.rs
@@ -413,10 +413,10 @@ impl DrgModio for modio::Modio {
         &self,
         name_id: &str,
     ) -> Result<Vec<ModioModResponse>, DrgModioError> {
-        use modio::filter::{Eq, In};
-        use modio::mods::filters::{NameId, Visible};
+        use modio::filter::Eq;
+use modio::mods::filters::NameId;
 
-        let filter = NameId::eq(name_id).and(Visible::_in(vec![0, 1]));
+        let filter = NameId::eq(name_id);
         Ok(self
             .game(MODIO_DRG_ID)
             .mods()

--- a/src/providers/modio.rs
+++ b/src/providers/modio.rs
@@ -323,7 +323,7 @@ impl DrgModio for modio::Modio {
     }
 
     async fn fetch_mod(&self, url: String, id: u32) -> Result<ModioMod, DrgModioError> {
-        use modio::filter::NotEq;
+        use modio::filter::{In, NotEq};
         use modio::mods::filters::Id;
 
         let files = self
@@ -337,18 +337,24 @@ impl DrgModio for modio::Modio {
                 mod_id: id,
                 url: url.clone(),
             })?;
-        let r#mod = self
+
+        let mods = self
             .game(MODIO_DRG_ID)
-            .mod_(id)
-            .get()
+            .mods()
+            .search(Id::_in(vec![id]))
+            .collect()
             .await
             .context(FetchModFailedSnafu { mod_id: id, url })?;
+
+        let r#mod = mods.into_iter().next().ok_or(DrgModioError::GenericError {
+            msg: "mod.io returned no mod for the requested ID",
+        })?;
 
         Ok(ModioMod::new(r#mod, files))
     }
 
     async fn fetch_files(&self, url: String, mod_id: u32) -> Result<ModioMod, DrgModioError> {
-        use modio::filter::NotEq;
+        use modio::filter::{In, NotEq};
         use modio::mods::filters::Id;
 
         let files = self
@@ -362,12 +368,18 @@ impl DrgModio for modio::Modio {
                 mod_id,
                 url: url.clone(),
             })?;
-        let r#mod = self
+
+        let mods = self
             .game(MODIO_DRG_ID)
-            .mod_(mod_id)
-            .get()
+            .mods()
+            .search(Id::_in(vec![mod_id]))
+            .collect()
             .await
             .context(FetchModFailedSnafu { mod_id, url })?;
+
+        let r#mod = mods.into_iter().next().ok_or(DrgModioError::GenericError {
+            msg: "mod.io returned no mod for the requested ID",
+        })?;
 
         Ok(ModioMod::new(r#mod, files))
     }
@@ -378,18 +390,25 @@ impl DrgModio for modio::Modio {
         mod_id: u32,
         modfile_id: u32,
     ) -> Result<modio::files::File, DrgModioError> {
-        let file = self
+        use modio::files::filters::Id;
+        use modio::filter::Eq;
+
+        let files = self
             .game(MODIO_DRG_ID)
             .mod_(mod_id)
-            .file(modfile_id)
-            .get()
+            .files()
+            .search(Id::eq(modfile_id))
+            .collect()
             .await
             .with_context(|_| FetchModFileFailedSnafu {
-                url,
+                url: url.clone(),
                 mod_id,
                 modfile_id,
             })?;
-        Ok(file)
+
+        files.into_iter().next().ok_or(DrgModioError::GenericError {
+            msg: "mod.io returned no mod file for the requested ID",
+        })
     }
 
     async fn fetch_dependencies(
@@ -414,7 +433,7 @@ impl DrgModio for modio::Modio {
         name_id: &str,
     ) -> Result<Vec<ModioModResponse>, DrgModioError> {
         use modio::filter::Eq;
-use modio::mods::filters::NameId;
+        use modio::mods::filters::NameId;
 
         let filter = NameId::eq(name_id);
         Ok(self


### PR DESCRIPTION
mod.io recently changed their API, which caused downloading new mods to fail with a 403 error. This change removes the code responsible for the issue and restores functionality for downloading new mods from mod.io.

If this PR is approved, it would also be great to publish a new release so users who don't build MINT from source can benefit from the fix as well.